### PR TITLE
Add explicit nullable param types (PHP 8.4 deprecation)

### DIFF
--- a/src/Controller/GdprBannerController.php
+++ b/src/Controller/GdprBannerController.php
@@ -242,7 +242,7 @@ class GdprBannerController extends MelisAbstractActionController
      * @param Form|null $form
      * @return array
      */
-    private function formatErrorMsg(Form $form = null)
+    private function formatErrorMsg(?Form $form = null)
     {
         $formattedErrors = [];
         $formErrors = $form->getMessages();


### PR DESCRIPTION
## What

PHP 8.4 deprecates **implicitly nullable parameters** (`Type $x = null`). This makes them explicit (`?Type $x = null`) in `src/`.

## Safety

**Behaviour-preserving** (PHP already treats `Type $x = null` as nullable). Generated with PHP-CS-Fixer (`nullable_type_declaration_for_default_null_value`), `php -l` clean — `?`-only changes, no logic change.

## Context

Part of the PHP 8.4 support effort (melisplatform/melis-core#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)